### PR TITLE
fix: Update default admin phone and address in seedAdmin script

### DIFF
--- a/server/scripts/seedAdmin.js
+++ b/server/scripts/seedAdmin.js
@@ -23,8 +23,10 @@ for (const envVar of requiredEnvVars) {
 const adminConfig = {
   name: process.env.ADMIN_NAME || "FlightDrone Admin",
   email: process.env.ADMIN_EMAIL || "admin@flightdrone.com",
-  phone: process.env.ADMIN_PHONE || "9999999999",
-  address: process.env.ADMIN_ADDRESS || "FlightDrone HQ",
+  phone: process.env.ADMIN_PHONE || "9236993440",
+  address: process.env.ADMIN_ADDRESS || `Flytium Drones
+H. N0 - 49C Near Paidleganj,Gorakhpur, Uttar Pradesh
+India`,
   password: process.env.ADMIN_PASSWORD || "Admin@123",
   answer: process.env.ADMIN_SECURITY_ANSWER || "flightdrone",
 };


### PR DESCRIPTION
This pull request updates the default admin contact information in the `server/scripts/seedAdmin.js` script. The changes ensure that the seeded admin user has more realistic and specific default values for phone and address.

* Updated the default `phone` value to `9236993440` for the admin user.
* Changed the default `address` value to a multi-line, detailed address for Flytium Drones in Gorakhpur, Uttar Pradesh, India.